### PR TITLE
installation location fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Login 40x faster than proot-distro.
 On Termux:
 
 ```sh
-cc -o "${PREFIX}/prootie" prootie.c -s -Os
+cc -o "${PREFIX}/bin/prootie" prootie.c -s -Os
 ```
 
 On Linux:


### PR DESCRIPTION
was `cc -o "${PREFIX}/prootie" prootie.c -s -Os`

but $PREFIX mean `usr` directory so it should be /usr/bin